### PR TITLE
feat: add notification history drawer and fix cold-start navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo/vector-icons": "^15.0.3",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -3683,6 +3684,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -11990,6 +12003,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo/vector-icons": "^15.0.3",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import * as Notifications from "expo-notifications";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { AuthProvider, useAuth } from "@/context/AuthContext";
 import { ThemeProvider } from "@/context/ThemeContext";
+import { NotificationHistoryProvider } from "@/context/NotificationHistoryContext";
 import { useNotificationSetup } from "@/hooks/useNotificationSetup";
 import "../global.css";
 import { getNotificationImage } from "@/services/notifications";
@@ -112,9 +113,11 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <AuthProvider>
-          <AuthGuard />
-        </AuthProvider>
+        <NotificationHistoryProvider>
+          <AuthProvider>
+            <AuthGuard />
+          </AuthProvider>
+        </NotificationHistoryProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -12,6 +12,7 @@ import {
   Clock,
   Heart,
   MessageCircle,
+  Bell,
 } from "lucide-react-native";
 import { listAllPosts, getUserById, listStories, likePost } from "@/api/generated/api";
 import {
@@ -25,8 +26,10 @@ import {
 import { MasonryGrid } from "@/components/MasonryGrid";
 import { StoryStrip } from "@/components/StoryStrip";
 import { HeartBurst } from "@/components/HeartBurst";
+import { NotificationDrawer } from "@/components/NotificationDrawer";
 import { useAuth } from "@/context/AuthContext";
 import { useTheme } from "@/context/ThemeContext";
+import { useNotificationHistory } from "@/context/NotificationHistoryContext";
 
 type Filters = {
   order: ListAllPostsOrder;
@@ -49,9 +52,11 @@ export default function HomeScreen() {
   });
   const [showFilters, setShowFilters] = useState(false);
   const [burstKey, setBurstKey] = useState(0);
+  const [notifDrawerOpen, setNotifDrawerOpen] = useState(false);
   const { isDarkMode } = useTheme();
   const router = useRouter();
   const { user } = useAuth();
+  const { unreadCount } = useNotificationHistory();
 
   // ── FAB scroll-aware visibility ──
   const fabAnim = useRef(new Animated.Value(1)).current as any;
@@ -368,7 +373,32 @@ export default function HomeScreen() {
           className={`pt-14 px-4 pb-3 flex-row items-center justify-between ${isDarkMode ? "bg-gray-900" : "bg-white"}`}
           style={{ shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 4, elevation: 3 }}
         >
-          <View style={{ width: 36 }} />
+          <TouchableOpacity
+            onPress={() => setNotifDrawerOpen(true)}
+            style={{ width: 36, height: 36, alignItems: "center", justifyContent: "center" }}
+          >
+            <Bell size={22} color={isDarkMode ? "#f9fafb" : "#111827"} />
+            {unreadCount > 0 && (
+              <View
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  right: 0,
+                  minWidth: 16,
+                  height: 16,
+                  borderRadius: 8,
+                  backgroundColor: "#ef4444",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  paddingHorizontal: 3,
+                }}
+              >
+                <Text style={{ color: "#fff", fontSize: 10, fontWeight: "700" }}>
+                  {unreadCount > 99 ? "99+" : unreadCount}
+                </Text>
+              </View>
+            )}
+          </TouchableOpacity>
           <Text className={`text-lg font-bold ${isDarkMode ? "text-white" : "text-gray-900"}`}>
             Mural de Fotos
           </Text>
@@ -402,6 +432,9 @@ export default function HomeScreen() {
 
         {/* ── Heart burst animation on double-tap like ── */}
         {burstKey > 0 && <HeartBurst key={burstKey} />}
+
+        {/* ── Notification drawer ── */}
+        <NotificationDrawer visible={notifDrawerOpen} onClose={() => setNotifDrawerOpen(false)} />
 
         {/* ── Floating Action Button ── */}
         <Animated.View

--- a/src/components/NotificationDrawer.tsx
+++ b/src/components/NotificationDrawer.tsx
@@ -1,0 +1,282 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { Animated, Dimensions, FlatList, Modal, Text, TouchableOpacity, View } from "react-native";
+import {
+  Bell,
+  BookOpen,
+  Clock,
+  Globe2,
+  Heart,
+  Image as ImageIcon,
+  MessageCircle,
+  Trash2,
+  User,
+} from "lucide-react-native";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/context/ThemeContext";
+import {
+  NotificationHistoryItem,
+  useNotificationHistory,
+} from "@/context/NotificationHistoryContext";
+import { getNotificationRoute, NotificationData } from "@/services/notifications";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+const DRAWER_WIDTH = Math.round(SCREEN_WIDTH * 0.85);
+
+function timeAgo(date: string): string {
+  const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
+  if (seconds < 60) return "agora";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function NotifIcon({ data }: { data: NotificationData | null }) {
+  if (!data) return <Bell size={18} color="#6b7280" />;
+  switch (data.type) {
+    case "like":
+      return <Heart size={18} color="#ef4444" fill="#ef4444" />;
+    case "comment":
+      return <MessageCircle size={18} color="#4f46e5" />;
+    case "face_detected":
+      return <User size={18} color="#0ea5e9" />;
+    case "new_post":
+      return <ImageIcon size={18} color="#10b981" />;
+    case "memory_reminder":
+      return <Clock size={18} color="#f59e0b" />;
+    case "user_retrospective_story":
+      return <BookOpen size={18} color="#8b5cf6" />;
+    case "global_retrospective_story":
+      return <Globe2 size={18} color="#f97316" />;
+    default:
+      return <Bell size={18} color="#6b7280" />;
+  }
+}
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function NotificationDrawer({ visible, onClose }: Props) {
+  const { isDarkMode } = useTheme();
+  const { notifications, unreadCount, markAllRead, clearAll } = useNotificationHistory();
+  const router = useRouter();
+
+  const slideAnim = useRef(new Animated.Value(DRAWER_WIDTH)).current;
+  const overlayAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      if (unreadCount > 0) markAllRead();
+      Animated.parallel([
+        Animated.spring(slideAnim, {
+          toValue: 0,
+          useNativeDriver: true,
+          bounciness: 0,
+          speed: 20,
+        }),
+        Animated.timing(overlayAnim, {
+          toValue: 1,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else {
+      Animated.parallel([
+        Animated.timing(slideAnim, {
+          toValue: DRAWER_WIDTH,
+          duration: 180,
+          useNativeDriver: true,
+        }),
+        Animated.timing(overlayAnim, {
+          toValue: 0,
+          duration: 180,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [visible]);
+
+  const handlePressItem = useCallback(
+    (item: NotificationHistoryItem) => {
+      if (!item.data) return;
+      const route = getNotificationRoute(item.data);
+      if (!route) return;
+      onClose();
+      setTimeout(() => router.push(route), 200);
+    },
+    [onClose, router]
+  );
+
+  const bg = isDarkMode ? "#111827" : "#ffffff";
+  const headerBg = isDarkMode ? "#1f2937" : "#f9fafb";
+  const textPrimary = isDarkMode ? "#f9fafb" : "#111827";
+  const textMuted = isDarkMode ? "#9ca3af" : "#6b7280";
+  const border = isDarkMode ? "#374151" : "#e5e7eb";
+  const iconCircleBg = isDarkMode ? "#374151" : "#f3f4f6";
+  const unreadBg = isDarkMode ? "#1e1b4b" : "#eef2ff";
+
+  const renderItem = ({ item }: { item: NotificationHistoryItem }) => (
+    <TouchableOpacity
+      onPress={() => handlePressItem(item)}
+      activeOpacity={item.data ? 0.7 : 1}
+      style={{
+        flexDirection: "row",
+        alignItems: "flex-start",
+        gap: 12,
+        paddingHorizontal: 16,
+        paddingVertical: 14,
+        backgroundColor: item.read ? "transparent" : unreadBg,
+        borderBottomWidth: 1,
+        borderBottomColor: border,
+      }}
+    >
+      <View
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          backgroundColor: iconCircleBg,
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <NotifIcon data={item.data} />
+      </View>
+
+      <View style={{ flex: 1 }}>
+        {!!item.title && (
+          <Text
+            style={{
+              color: textPrimary,
+              fontSize: 13,
+              fontWeight: item.read ? "400" : "600",
+              marginBottom: 2,
+            }}
+            numberOfLines={1}
+          >
+            {item.title}
+          </Text>
+        )}
+        {!!item.body && (
+          <Text style={{ color: textMuted, fontSize: 12, lineHeight: 18 }} numberOfLines={2}>
+            {item.body}
+          </Text>
+        )}
+      </View>
+
+      <Text style={{ color: textMuted, fontSize: 11, flexShrink: 0, marginTop: 2 }}>
+        {timeAgo(item.receivedAt)}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      {/* Dark overlay — tapping closes the drawer */}
+      <Animated.View
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: "rgba(0,0,0,0.5)",
+          opacity: overlayAnim,
+        }}
+      >
+        <TouchableOpacity style={{ flex: 1 }} onPress={onClose} activeOpacity={1} />
+      </Animated.View>
+
+      {/* Drawer panel */}
+      <Animated.View
+        style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: DRAWER_WIDTH,
+          backgroundColor: bg,
+          transform: [{ translateX: slideAnim }],
+          shadowColor: "#000",
+          shadowOffset: { width: -4, height: 0 },
+          shadowOpacity: 0.15,
+          shadowRadius: 12,
+          elevation: 16,
+        }}
+      >
+        {/* Header */}
+        <View
+          style={{
+            paddingTop: 56,
+            paddingBottom: 14,
+            paddingHorizontal: 16,
+            backgroundColor: headerBg,
+            borderBottomWidth: 1,
+            borderBottomColor: border,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Text style={{ color: textPrimary, fontSize: 17, fontWeight: "700" }}>Notificações</Text>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
+            {unreadCount > 0 && (
+              <TouchableOpacity
+                onPress={markAllRead}
+                style={{
+                  paddingHorizontal: 10,
+                  paddingVertical: 5,
+                  borderRadius: 999,
+                  backgroundColor: "#4f46e5",
+                }}
+              >
+                <Text style={{ color: "#fff", fontSize: 11, fontWeight: "600" }}>Marcar lidas</Text>
+              </TouchableOpacity>
+            )}
+            {notifications.length > 0 && (
+              <TouchableOpacity onPress={clearAll} hitSlop={8}>
+                <Trash2 size={18} color={textMuted} />
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+
+        {/* List or empty state */}
+        {notifications.length === 0 ? (
+          <View
+            style={{
+              flex: 1,
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 12,
+              paddingHorizontal: 32,
+            }}
+          >
+            <Bell size={44} color={isDarkMode ? "#374151" : "#d1d5db"} />
+            <Text style={{ color: textMuted, fontSize: 14, textAlign: "center", lineHeight: 20 }}>
+              Nenhuma notificação recebida nesta sessão.
+            </Text>
+          </View>
+        ) : (
+          <FlatList
+            data={notifications}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={{ paddingBottom: 40 }}
+          />
+        )}
+      </Animated.View>
+    </Modal>
+  );
+}

--- a/src/context/NotificationHistoryContext.tsx
+++ b/src/context/NotificationHistoryContext.tsx
@@ -1,0 +1,91 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { NotificationData } from "@/services/notifications";
+
+export type NotificationHistoryItem = {
+  id: string;
+  title: string;
+  body: string;
+  data: NotificationData | null;
+  receivedAt: string; // ISO string para serialização
+  read: boolean;
+};
+
+type NotificationHistoryContextType = {
+  notifications: NotificationHistoryItem[];
+  unreadCount: number;
+  addNotification: (item: Pick<NotificationHistoryItem, "title" | "body" | "data">) => void;
+  markAllRead: () => void;
+  clearAll: () => void;
+};
+
+const NotificationHistoryContext = createContext<NotificationHistoryContextType | null>(null);
+
+const STORAGE_KEY = "@mural:notification_history";
+const MAX_NOTIFICATIONS = 50;
+
+export function NotificationHistoryProvider({ children }: { children: React.ReactNode }) {
+  const [notifications, setNotifications] = useState<NotificationHistoryItem[]>([]);
+  const counterRef = useRef(0);
+  const initialized = useRef(false);
+
+  // Carrega do storage na inicialização
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (raw) {
+          const parsed = JSON.parse(raw) as NotificationHistoryItem[];
+          setNotifications(parsed);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        initialized.current = true;
+      });
+  }, []);
+
+  // Persiste sempre que a lista muda (após inicialização)
+  useEffect(() => {
+    if (!initialized.current) return;
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(notifications)).catch(() => {});
+  }, [notifications]);
+
+  const addNotification = useCallback(
+    (item: Pick<NotificationHistoryItem, "title" | "body" | "data">) => {
+      counterRef.current += 1;
+      const newItem: NotificationHistoryItem = {
+        ...item,
+        id: `notif-${Date.now()}-${counterRef.current}`,
+        receivedAt: new Date().toISOString(),
+        read: false,
+      };
+      setNotifications((prev) => [newItem, ...prev].slice(0, MAX_NOTIFICATIONS));
+    },
+    []
+  );
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setNotifications([]);
+  }, []);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return (
+    <NotificationHistoryContext.Provider
+      value={{ notifications, unreadCount, addNotification, markAllRead, clearAll }}
+    >
+      {children}
+    </NotificationHistoryContext.Provider>
+  );
+}
+
+export function useNotificationHistory() {
+  const ctx = useContext(NotificationHistoryContext);
+  if (!ctx)
+    throw new Error("useNotificationHistory deve ser usado dentro de NotificationHistoryProvider");
+  return ctx;
+}

--- a/src/hooks/useNotificationSetup.ts
+++ b/src/hooks/useNotificationSetup.ts
@@ -13,14 +13,17 @@ import {
   getNotificationRoute,
   parseNotificationData,
 } from "@/services/notifications";
+import { useNotificationHistory } from "@/context/NotificationHistoryContext";
 
 export function useNotificationSetup() {
   const router = useRouter();
-  const { user, justLoggedIn } = useAuth();
+  const { user, justLoggedIn, isLoading } = useAuth();
+  const { addNotification } = useNotificationHistory();
 
   const responseListener = useRef<Notifications.EventSubscription | null>(null);
   const receivedListener = useRef<Notifications.EventSubscription | null>(null);
   const isReady = useRef(false);
+  const initialNotifHandled = useRef(false);
 
   const [banner, setBanner] = useState<{
     title: string | null;
@@ -53,6 +56,9 @@ export function useNotificationSetup() {
     const imageUrl = getNotificationImage(notification);
     const title = notification.request.content.title ?? "";
     const body = notification.request.content.body ?? "";
+    const data = parseNotificationData(notification);
+
+    addNotification({ title, body, data });
 
     if (imageUrl) {
       if (Platform.OS === "android") {
@@ -101,18 +107,24 @@ export function useNotificationSetup() {
       handleNotificationReceived
     );
 
-    // Caso o app tenha sido aberto a partir de uma notificação
-    Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (response) {
-        handleNotificationResponse(response);
-      }
-    });
-
     return () => {
       responseListener.current?.remove();
       receivedListener.current?.remove();
     };
   }, [user, justLoggedIn, router]);
+
+  // Trata o caso em que o app foi aberto a partir de uma notificação (cold start).
+  // Só executa após a autenticação estar resolvida e apenas uma vez.
+  useEffect(() => {
+    if (isLoading || !user || initialNotifHandled.current) return;
+
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) {
+        initialNotifHandled.current = true;
+        handleNotificationResponse(response);
+      }
+    });
+  }, [isLoading, user, router]);
 
   return { banner, setBanner }; // Retornamos para renderizar o banner no layout
 }


### PR DESCRIPTION
  - Fix infinite loading when tapping push notifications on cold start:
    getLastNotificationResponseAsync now runs only after auth resolves
    and is guarded by a ref to prevent duplicate navigation calls
  - Add NotificationHistoryContext to store received notifications with
    AsyncStorage persistence across sessions (max 50 items)
  - Add NotificationDrawer slide-in panel accessible from a bell icon
    in the home top bar, with unread badge, type icons, and time display
  - Install @react-native-async-storage/async-storage for persistence
