### PR TITLE
fix: revert android icons from svg to png to fix eas build error

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "mural-de-fotos",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/images/unir.svg",
+    "icon": "./assets/images/icon.png",
     "scheme": "muralmobile",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
@@ -18,9 +18,9 @@
     "android": {
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
-        "foregroundImage": "./assets/images/unir.svg",
-        "backgroundImage": "./assets/images/unir.svg",
-        "monochromeImage": "./assets/images/unir.svg"
+        "foregroundImage": "./assets/images/icon.png",
+        "backgroundImage": "./assets/images/icon.png",
+        "monochromeImage": "./assets/images/icon.png"
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
@@ -32,14 +32,14 @@
     "web": {
       "bundler": "metro",
       "output": "static",
-      "favicon": "./assets/images/unir.svg"
+      "favicon": "./assets/images/icon.png"
     },
     "plugins": [
       "expo-router",
       [
         "expo-notifications",
         {
-          "icon": "./assets/images/unir.svg",
+          "icon": "./assets/images/icon.png",
           "color": "#4f46e5",
           "defaultChannel": "default",
           "sounds": [],
@@ -49,7 +49,7 @@
       [
         "expo-splash-screen",
         {
-          "image": "./assets/images/unir.svg",
+          "image": "./assets/images/icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
           "backgroundColor": "#ffffff",


### PR DESCRIPTION
## Summary
- Corrige erro de build no Android: `Invalid mimeType for image with source: ./assets/images/unir.svg`
- SVG não é suportado pelo pipeline de build do Android (`withAndroidIcons`) — requer PNG ou JPEG
- Reverte todas as referências de ícone no `app.json` de `unir.svg` para `icon.png`

## Root cause
O commit `5f2b30e` atualizou os ícones para `unir.svg` no `main`, mas o Expo não consegue processar SVG para gerar os adaptive icons do Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)